### PR TITLE
Try new version

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -80,7 +80,7 @@ grails.project.dependency.resolution = {
         //compile ":handlebars-asset-pipeline:1.3.0.1"
         compile ":markdown:1.1.1"
         compile ':i18n-enums:1.0.1'
-        test ":code-coverage:2.0.3-1"
+        test ":code-coverage:2.0.3-2-SNAPSHOT"
 
     }
 }


### PR DESCRIPTION
To test this fix you will need to build the coverage plugin locally with the following steps in the coverage plugin project
- `grails package`
- `grails mavenInstall`

Then run the tests with coverage in this one.
